### PR TITLE
Fixed library installation via pip2/pip3 on a Raspberry Pi

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@ build
 .idea
 dist
 *.egg-info
+bin
+obj
+*.pyc
+__pycache__

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,7 +4,7 @@ include Api/core/src/vl53l0x_api_ranging.c
 include Api/core/src/vl53l0x_api_strings.c
 include Api/core/src/vl53l0x_api.c
 include platform/src/vl53l0x_platform.c
-include python_lib/src/vl53l0x_platform.c
-include VL53L0X/VL53L0X.py
+include python_lib/vl53l0x_python.c
+include python/VL53L0X.py
 include README.md
-include setup.py 
+include setup.py

--- a/Makefile
+++ b/Makefile
@@ -50,5 +50,5 @@ $(OBJ_DIR)/%.o:%.c
 
 .PHONY: clean
 clean:
-	-${RM} -rf ./$(OUTPUT_DIR)/*  ./$(OBJ_DIR)/*
+	-${RM} -rf ./$(OUTPUT_DIR) ./$(OBJ_DIR)
 

--- a/README.md
+++ b/README.md
@@ -45,9 +45,9 @@ Notes on using TCA9548A I2C Multiplexer:
 ### Installation
 ```bash
 # Python2
-pip2 install git+https://github.com/naisy/VL53L0X_rasp_python.git
+pip2 install git+https://github.com/pimoroni/VL53L0X-python.git
 # Python3
-pip3 install git+https://github.com/naisy/VL53L0X_rasp_python.git
+pip3 install git+https://github.com/pimoroni/VL53L0X-python.git
 ```
 
 ### Compilation
@@ -60,8 +60,8 @@ sudo apt-get install build-essential python-dev
 Then use following commands to clone the repository and compile:
 ```bash
 cd your_git_directory
-git clone https://github.com/naisy/VL53L0X_rasp_python.git
-cd VL53L0X_rasp_python
+git clone https://github.com/pimoroni/VL53L0X_rasp_python.git
+cd VL53L0X-python
 make
 ```
 

--- a/python/VL53L0X.py
+++ b/python/VL53L0X.py
@@ -22,6 +22,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 from ctypes import CDLL, CFUNCTYPE, POINTER, c_int, c_uint, pointer, c_ubyte, c_uint8, c_uint32
+import importlib
 import pkg_resources
 SMBUS='smbus'
 for dist in pkg_resources.working_set:
@@ -78,13 +79,18 @@ _I2C_READ_FUNC = CFUNCTYPE(c_int, c_ubyte, c_ubyte, POINTER(c_ubyte), c_ubyte)
 _I2C_WRITE_FUNC = CFUNCTYPE(c_int, c_ubyte, c_ubyte, POINTER(c_ubyte), c_ubyte)
 
 # Load VL53L0X shared lib
-_POSSIBLE_LIBRARY_LOCATIONS = ['../bin'] + site.getsitepackages()
+_POSSIBLE_LIBRARY_LOCATIONS = ['../bin'] + site.getsitepackages() + [site.getusersitepackages()]
+_POSSIBLE_LIBRARY_SUFFIXIES = importlib.machinery.EXTENSION_SUFFIXES
 for lib_location in _POSSIBLE_LIBRARY_LOCATIONS:
-    try:
-        _TOF_LIBRARY = CDLL(lib_location + "/vl53l0x_python.so")
-        break
-    except OSError:
-        pass
+    for suffix in _POSSIBLE_LIBRARY_SUFFIXIES:
+        try:
+            _TOF_LIBRARY = CDLL(lib_location + "/vl53l0x_python" + suffix)
+            break
+        except OSError:
+            pass
+    else:
+        continue
+    break
 else:
     raise OSError('Could not find vl53l0x_python.so')
 

--- a/python/VL53L0X.py
+++ b/python/VL53L0X.py
@@ -22,7 +22,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 from ctypes import CDLL, CFUNCTYPE, POINTER, c_int, c_uint, pointer, c_ubyte, c_uint8, c_uint32
-import importlib
+import sysconfig
 import pkg_resources
 SMBUS='smbus'
 for dist in pkg_resources.working_set:
@@ -79,20 +79,18 @@ _I2C_READ_FUNC = CFUNCTYPE(c_int, c_ubyte, c_ubyte, POINTER(c_ubyte), c_ubyte)
 _I2C_WRITE_FUNC = CFUNCTYPE(c_int, c_ubyte, c_ubyte, POINTER(c_ubyte), c_ubyte)
 
 # Load VL53L0X shared lib
+suffix = sysconfig.get_config_var('EXT_SUFFIX')
+if suffix is None:
+    suffix = ".so"
 _POSSIBLE_LIBRARY_LOCATIONS = ['../bin'] + site.getsitepackages() + [site.getusersitepackages()]
-_POSSIBLE_LIBRARY_SUFFIXIES = importlib.machinery.EXTENSION_SUFFIXES
 for lib_location in _POSSIBLE_LIBRARY_LOCATIONS:
-    for suffix in _POSSIBLE_LIBRARY_SUFFIXIES:
-        try:
-            _TOF_LIBRARY = CDLL(lib_location + "/vl53l0x_python" + suffix)
-            break
-        except OSError:
-            pass
-    else:
-        continue
-    break
+    try:
+        _TOF_LIBRARY = CDLL(lib_location + '/vl53l0x_python' + suffix)
+        break
+    except OSError:
+        pass
 else:
-    raise OSError('Could not find vl53l0x_python.so')
+    raise OSError('Could not find vl53l0x_python' + suffix)
 
 
 class VL53L0X:

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(name='VL53L0X',
       description='VL53L0X sensor for raspberry PI/JetsonTX2',
       # author='?',
       # author_email='?',
-      url='https://github.com/pimoroni/VL53L0X_rasp_python',
+      url='https://github.com/pimoroni/VL53L0X-python',
       long_description='''
 VL53L0X sensor for raspberry PI/JetsonTX2.
 ''',


### PR DESCRIPTION
Fix for an issue, when due to machine suffixes used to name locally builded .so file on a Raspbian GNU/Linux 10 (buster), it's unable to install library properly. Also some links in README.md fixed to point to really used repository, not the original one.
